### PR TITLE
bug fix #11

### DIFF
--- a/src/Quilljs.php
+++ b/src/Quilljs.php
@@ -50,9 +50,9 @@ class Quilljs extends Trix
         return $value == true ? $this->withMeta(['tooltip'=> config('tooltip') ?? []]) : null;
     }
 
-    public function placeholder(string $value)
+    public function placeholder($text)
     {
-        return $this->withMeta(['placeholder'=> $value]);
+        return $this->withMeta(['placeholder'=> $text]);
     }
 
     public function height(int $value=300)


### PR DESCRIPTION
This fixes the next error:

```
Declaration of Ek0519\Quilljs\Quilljs::placeholder(string $value) should be compatible with Laravel\Nova\Fields\Field::placeholder($text) {"userId":1,"exception":"[object] (ErrorException(code: 0): Declaration of Ek0519\\Quilljs\\Quilljs::placeholder(string $value) should be compatible with Laravel\\Nova\\Fields\\Field::placeholder($text) at /vendor/ek0519/quilljs/src/Quilljs.php:53)
```

fix #11 