### PR TITLE
Pending Image Persistence Bug Fix

### DIFF
--- a/src/Quilljs.php
+++ b/src/Quilljs.php
@@ -57,6 +57,7 @@ class Quilljs extends Trix
     {
         foreach($images as $image) {
             $pending = PendingAttachment::where('draft_id', $image)->first();
+            info(print_r($pending, true));
 //            debug($pending, $image, $model, $this->getStorageDisk());
             if ($pending) {
                 $pending->persist($this, $model);

--- a/src/Quilljs.php
+++ b/src/Quilljs.php
@@ -44,6 +44,7 @@ class Quilljs extends Trix
                                                 $attribute)
     {
         if ($request->exists($requestAttribute)) {
+            info(print_r($model, true));
             $model->{$attribute} = $request[$requestAttribute];
             if ($request->persisted && $images = json_decode($request->persisted)) {
                 if (!empty($images)) {
@@ -57,7 +58,6 @@ class Quilljs extends Trix
     {
         foreach($images as $image) {
             $pending = PendingAttachment::where('draft_id', $image)->first();
-            info(print_r($pending, true));
 //            debug($pending, $image, $model, $this->getStorageDisk());
             if ($pending) {
                 $pending->persist($this, $model);

--- a/src/Quilljs.php
+++ b/src/Quilljs.php
@@ -47,7 +47,6 @@ class Quilljs extends Trix
             $model->{$attribute} = $request[$requestAttribute];
 
             $modelClass = get_class($model);
-            info($modelClass);
             call_user_func_array("$modelClass::created", [
                 function($object) use ($request) {
                     if ($request->persisted && $images = json_decode($request->persisted)) {

--- a/src/Quilljs.php
+++ b/src/Quilljs.php
@@ -46,16 +46,27 @@ class Quilljs extends Trix
         if ($request->exists($requestAttribute)) {
             $model->{$attribute} = $request[$requestAttribute];
 
-            $modelClass = get_class($model);
-            call_user_func_array("$modelClass::created", [
-                function($object) use ($request) {
-                    if ($request->persisted && $images = json_decode($request->persisted)) {
-                        if (!empty($images)) {
-                            $this->persistedImg($images, $object);
-                        }
+            if (! isset($model->id)) {
+                $quilljs = $this;
+                $modelClass = get_class($model);
+                call_user_func_array("$modelClass::created", [
+                    function($object) use ($quilljs, $request) {
+                        $quilljs->persistImages($request, $object);
                     }
-                }
-            ]);
+                ]);
+            }
+            else {
+                $this->persistImages($request, $model);
+            }
+
+        }
+    }
+
+    function persistImages(NovaRequest $request, $object) {
+        if ($request->persisted && $images = json_decode($request->persisted)) {
+            if (!empty($images)) {
+                $this->persistedImg($images, $object);
+            }
         }
     }
 

--- a/src/Quilljs.php
+++ b/src/Quilljs.php
@@ -44,13 +44,18 @@ class Quilljs extends Trix
                                                 $attribute)
     {
         if ($request->exists($requestAttribute)) {
-            info(print_r($model, true));
             $model->{$attribute} = $request[$requestAttribute];
-            if ($request->persisted && $images = json_decode($request->persisted)) {
-                if (!empty($images)) {
-                    $this->persistedImg($images, $model);
+
+            $modelClass = get_class($model);
+            info($modelClass);
+            $modelClass::created(function($object) use ($request) {
+                if ($request->persisted && $images = json_decode($request->persisted)) {
+                    if (!empty($images)) {
+                        $this->persistedImg($images, $object);
+                    }
                 }
-            }
+            });
+
         }
     }
 

--- a/src/Quilljs.php
+++ b/src/Quilljs.php
@@ -48,14 +48,15 @@ class Quilljs extends Trix
 
             $modelClass = get_class($model);
             info($modelClass);
-            $modelClass::created(function($object) use ($request) {
-                if ($request->persisted && $images = json_decode($request->persisted)) {
-                    if (!empty($images)) {
-                        $this->persistedImg($images, $object);
+            call_user_func_array("$modelClass::created", [
+                function($object) use ($request) {
+                    if ($request->persisted && $images = json_decode($request->persisted)) {
+                        if (!empty($images)) {
+                            $this->persistedImg($images, $object);
+                        }
                     }
                 }
-            });
-
+            ]);
         }
     }
 


### PR DESCRIPTION
We encountered a bug when adding images to the quill editor for a brand new resource/object being created in Nova. This was due to the fact that the `$model` in `fillAttributeFromRequest()` was a representation of the object to be created but **before** creation. To fix this, I added a check for if the **id** attribute was set on the `$model`, and if it wasn't, we performed the image persistence after creation (by hooking into the model class's `created()` static method).